### PR TITLE
Add camera fallback to file capture when getUserMedia unavailable

### DIFF
--- a/components/ImageUploader.tsx
+++ b/components/ImageUploader.tsx
@@ -77,6 +77,7 @@ const CloseIcon: React.FC<{ className?: string }> = ({ className }) => (
 
 const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageChange, imagePreviewUrl, disabled = false }) => {
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const cameraFileInputRef = useRef<HTMLInputElement>(null);
     const videoRef = useRef<HTMLVideoElement>(null);
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const streamRef = useRef<MediaStream | null>(null);
@@ -99,8 +100,11 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageChange, imagePrevi
     const handleClearImage = (e: React.MouseEvent) => {
         e.stopPropagation();
         onImageChange(null);
-        if(fileInputRef.current) {
+        if (fileInputRef.current) {
             fileInputRef.current.value = "";
+        }
+        if (cameraFileInputRef.current) {
+            cameraFileInputRef.current.value = "";
         }
     }
 
@@ -112,6 +116,17 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageChange, imagePrevi
     const handleOpenCamera = () => {
         setIsChoiceModalOpen(false);
         setCameraError(null);
+        const canUseMediaStream =
+            typeof window !== 'undefined' &&
+            window.isSecureContext &&
+            typeof navigator !== 'undefined' &&
+            !!navigator.mediaDevices?.getUserMedia;
+
+        if (!canUseMediaStream) {
+            cameraFileInputRef.current?.click();
+            return;
+        }
+
         setIsCameraOpen(true);
     };
 
@@ -267,6 +282,14 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageChange, imagePrevi
                 <input
                     type="file"
                     ref={fileInputRef}
+                    onChange={handleFileChange}
+                    accept="image/png, image/jpeg, image/webp, image/*"
+                    className="hidden"
+                    disabled={disabled}
+                />
+                <input
+                    type="file"
+                    ref={cameraFileInputRef}
                     onChange={handleFileChange}
                     accept="image/png, image/jpeg, image/webp, image/*"
                     capture="environment"


### PR DESCRIPTION
## Summary
- add a dedicated hidden file input with capture enabled for the camera option
- fall back to the file input capture flow when MediaStream APIs are unavailable while keeping library picker unchanged
- reset both hidden inputs when clearing the selected image so subsequent selections work consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc5367adac8331a93a6453780948be

## Summary by Sourcery

Add a fallback path for camera capture by clicking a hidden file input with capture enabled if getUserMedia is unavailable, and ensure inputs are reset on clear

New Features:
- Provide camera fallback using a hidden file input with capture attribute when MediaStream APIs are unavailable

Enhancements:
- Add a dedicated hidden file input and ref for camera capture
- Reset both library and camera file inputs when clearing the selected image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smarter camera capture that adapts to device/browser capabilities, automatically choosing the best available method.
* **Bug Fixes**
  * Camera option now reliably falls back to file selection when direct camera access isn’t supported.
  * Clearing an image fully resets inputs to prevent stale selections.
* **UX Improvements**
  * More consistent capture and preview flow with minor UI spacing adjustments.
  * Preserves familiar “From Library” and “Use Camera” options while improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->